### PR TITLE
Update openjdk to LTS 17

### DIFF
--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -23,8 +23,14 @@ openjdk-11:
   image:      'openjdk:11'
   entrypoint: 'java'
   filename:   'Main.java'
+
+openjdk-17:
+  image:      'openjdk:17'
+  entrypoint: 'java'
+  filename:   'Main.java'
+
 java:
-  use:        'openjdk-11'
+  use:        'openjdk-17'
 
 kotlin:
   image: 'schlaubiboy/kotlin:1.5.10-alpine'


### PR DESCRIPTION
With the release of the new Java LTS version I also want to add the new version to this project. For this I added Java 17 to the specs and linked the "java" spec to the new version.